### PR TITLE
Fix Windows IPC pipe path in Connection.java

### DIFF
--- a/src/main/java/meteordevelopment/discordipc/connection/Connection.java
+++ b/src/main/java/meteordevelopment/discordipc/connection/Connection.java
@@ -19,7 +19,7 @@ public abstract class Connection {
         if (os.contains("win")) {
             for (int i = 0; i < 10; i++) {
                 try {
-                    return new WinConnection("\\\\?\\pipe\\discord-ipc-" + i, callback);
+                    return new WinConnection("\\\\.\\pipe\\discord-ipc-" + i, callback);
                 } catch (IOException ignored) {}
             }
         }


### PR DESCRIPTION
The ambiguous path definition here would cause the pipe to be defined incorrectly on certain machines, failing the connection.