### PR TITLE
Fix Discord RPC on Windows

### DIFF
--- a/src/main/java/meteordevelopment/discordipc/connection/Connection.java
+++ b/src/main/java/meteordevelopment/discordipc/connection/Connection.java
@@ -19,7 +19,7 @@ public abstract class Connection {
         if (os.contains("win")) {
             for (int i = 0; i < 10; i++) {
                 try {
-                    return new WinConnection("\\\\?\\pipe\\discord-ipc-" + i, callback);
+                    return new WinConnection("\\\\.\\pipe\\discord-ipc-" + i, callback);
                 } catch (IOException ignored) {}
             }
         }


### PR DESCRIPTION
It seems like Discord changed the path name from "\\\\?\\pipe\\discord-ipc-" to "\\\\.\\pipe\\discord-ipc-", sadly i could not find any patch note for this.

On Unix systems it seems like its working, although im not too sure.
I tested it on windows, where it works again now, and on Arch Linux, where DiscordIPC.start() returns true (did not check if it shows up in discord).